### PR TITLE
Fix variables lost after code deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,24 @@ npm install
 ```
 
 2. Configure environment variables:
-   - Copy `.dev.vars.example` to `.dev.vars` for local development
-   - For production, set secrets using:
-```bash
-wrangler secret put BOT_TOKEN
-wrangler secret put CHAT_ID
-wrangler secret put CMC_API_KEY
-```
+   - **For local development**: Copy `.dev.vars.example` to `.dev.vars` and fill in your values
+   - **For production** (choose one method):
+
+     **Method 1: Cloudflare Dashboard (Recommended)**
+     - Go to [Cloudflare Dashboard](https://dash.cloudflare.com)
+     - Navigate to: Workers & Pages > crypto-bot > Settings > Variables and Secrets
+     - Add the following secrets:
+       - `BOT_TOKEN`: Your Telegram bot token
+       - `CHAT_ID`: Your Telegram chat ID
+       - `CMC_API_KEY`: Your CoinMarketCap API key
+     - ✅ **These secrets will persist across all deployments**
+
+     **Method 2: CLI (One-time setup)**
+     ```bash
+     wrangler secret put BOT_TOKEN
+     wrangler secret put CHAT_ID
+     wrangler secret put CMC_API_KEY
+     ```
 
 3. Local development:
 ```bash
@@ -47,3 +58,16 @@ npm run deploy
 The worker runs automatically every 2 hours (00:30, 02:30, 04:30, 06:30, 08:30, 10:30, 12:30, 14:30 UTC) as configured in `wrangler.toml`.
 
 You can also trigger it manually by making an HTTP request to the worker URL.
+
+## Troubleshooting
+
+### Variables Lost After Deployment
+
+**Problem**: Environment variables are missing or lost after pushing new code and deploying.
+
+**Solution**:
+- Environment variables must be set in the **Cloudflare Workers dashboard** to persist across deployments
+- Variables set via `wrangler secret put` are stored in the Cloudflare environment, not in your code
+- Follow the setup instructions above to configure secrets in the dashboard
+- Once set in the dashboard, they will remain configured even after new deployments
+- You do NOT need to reset them after each `wrangler deploy`

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,22 @@ compatibility_date = "2024-01-01"
 [triggers]
 crons = ["30 0,2,4,6,8,10,12,14 * * *"]
 
-# Environment variables (set via wrangler secret put)
-# BOT_TOKEN
-# CHAT_ID
-# CMC_API_KEY
+# ============================================================================
+# IMPORTANT: Environment Variables Configuration
+# ============================================================================
+# These secrets must be set in the Cloudflare Workers dashboard to persist
+# across deployments. Set them at:
+# Workers & Pages > crypto-bot > Settings > Variables and Secrets
+#
+# Required secrets:
+# - BOT_TOKEN: Your Telegram Bot Token
+# - CHAT_ID: Your Telegram Chat ID
+# - CMC_API_KEY: Your CoinMarketCap API Key
+#
+# Alternatively, you can set them via CLI (but dashboard is recommended):
+#   wrangler secret put BOT_TOKEN
+#   wrangler secret put CHAT_ID
+#   wrangler secret put CMC_API_KEY
+#
+# For local development, create a .dev.vars file (see .dev.vars.example)
+# ============================================================================


### PR DESCRIPTION
- Updated wrangler.toml with clear documentation on how to set environment variables via Cloudflare dashboard
- Enhanced README.md with detailed instructions for configuring secrets that persist across deployments
- Added troubleshooting section explaining why variables may be lost after deployment
- Recommended Cloudflare dashboard method over CLI for persistent secrets

This resolves the issue where environment variables (BOT_TOKEN, CHAT_ID, CMC_API_KEY) were lost after pushing new code and deploying.